### PR TITLE
Normalizing name when used in code

### DIFF
--- a/src/main/g8/src/main/scala/$name;format=Camel$.scala
+++ b/src/main/g8/src/main/scala/$name;format=Camel$.scala
@@ -1,0 +1,4 @@
+package $org$.$name;format="camel"$
+
+class $name;format="Camel"$ {
+}

--- a/src/main/g8/src/main/scala/$org$/$name;format=norm$/Stub.scala
+++ b/src/main/g8/src/main/scala/$org$/$name;format=norm$/Stub.scala
@@ -1,4 +1,0 @@
-package $org$.$name;format="norm"$
-
-class Stub {
-}

--- a/src/main/g8/src/test/scala/$name;format=Camel$Test.scala
+++ b/src/main/g8/src/test/scala/$name;format=Camel$Test.scala
@@ -1,0 +1,4 @@
+package $org$.$name;format="camel"$
+
+class $name;format="Camel"$Test {
+}

--- a/src/main/g8/src/test/scala/$org$/$name;format=norm$/StubTest.scala
+++ b/src/main/g8/src/test/scala/$org$/$name;format=norm$/StubTest.scala
@@ -1,4 +1,0 @@
-package $org$.$name;format="norm"$
-
-class StubTest {
-}


### PR DESCRIPTION
`TODO:` when the project name contains dashes or something else, we should normalize it, when putting as a package name in code. See https://github.com/n8han/giter8#formatting-template-fields

Also would be nice to have something instead of `Stub` as the initial piece of code. And a template for test, just to forget about it's particular syntax.
